### PR TITLE
Increase open files limit for thanos-store

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -50,6 +50,7 @@ thanos_query_grpc_listen_port: "19182"
 thanos_query_grpc_listen_address: "0.0.0.0:{{ thanos_query_grpc_listen_port }}"
 thanos_store_grpc_listen_port: "19183"
 thanos_store_grpc_listen_address: "0.0.0.0:{{ thanos_store_grpc_listen_port }}"
+thanos_store_open_files_limit: 8192
 
 thanos_web_prometheus_url: 'http://localhost:9090/'
 

--- a/templates/thanos-store.service.j2
+++ b/templates/thanos-store.service.j2
@@ -9,6 +9,7 @@ User={{ thanos_user }}
 Group={{ thanos_group }}
 ExecReload=/bin/kill -HUP $MAINPID
 ExecStart={{ thanos_bin_dir }}/thanos store {{ thanos_store_flags }}
+LimitNOFILE={{ thanos_store_open_files_limit }}
 
 SyslogIdentifier=thanos-store
 Restart=always


### PR DESCRIPTION
Upon startup, thanos-store takes a long time because it keeps hitting the default 1024 limit.